### PR TITLE
Created climber subsystem/tests/commands

### DIFF
--- a/commands/climber/moveclimber.py
+++ b/commands/climber/moveclimber.py
@@ -5,7 +5,7 @@ from ultime.autoproperty import autoproperty
 from ultime.command import Command
 
 
-class MovingClimber(Command):
+class MoveClimber(Command):
     def __init__(self, climber: Climber, state: Climber.State):
         super().__init__()
         self.climber = climber
@@ -17,23 +17,22 @@ class MovingClimber(Command):
 
     @abstractmethod
     def execute(self):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @abstractmethod
     def isFinished(self) -> bool:
         raise NotImplementedError()
 
-    @abstractmethod
     def end(self, interrupted: bool):
         self.climber.stop()
         if interrupted:
-            self.climber.state = Climber.State.Invalid
+            self.climber.state = Climber.State.Unknown
         else:
             self.climber.state = self.new_state
 
 
-class ReadyClimber(MovingClimber):
-    position_ready = autoproperty(5.0)
+class ReadyClimber(MoveClimber):
+    position = autoproperty(5.0)
 
     def __init__(self, climber: Climber):
         super().__init__(climber=climber, state=Climber.State.Ready)
@@ -42,10 +41,10 @@ class ReadyClimber(MovingClimber):
         self.climber.pull()
 
     def isFinished(self) -> bool:
-        return self.climber.getPosition() >= self.position_ready
+        return self.climber.getPosition() >= self.position
 
 
-class ClimbClimber(MovingClimber):
+class Climb(MoveClimber):
     def __init__(self, climber: Climber):
         super().__init__(climber=climber, state=Climber.State.Climbed)
 
@@ -53,10 +52,10 @@ class ClimbClimber(MovingClimber):
         self.climber.pull()
 
     def isFinished(self) -> bool:
-        return self.climber._switch.isPressed()
+        return self.climber.isClimbed()
 
 
-class ReleaseClimber(MovingClimber):
+class ReleaseClimber(MoveClimber):
     def __init__(self, climber: Climber):
         super().__init__(climber=climber, state=Climber.State.Initial)
 

--- a/commands/climber/moveclimber.py
+++ b/commands/climber/moveclimber.py
@@ -29,6 +29,7 @@ class MovingClimber(Command):
     def __init__(self, climber: Climber, state: Climber.State):
         super().__init__()
         self.climber = climber
+        self.addRequirements(self.climber)
         self.new_state = state
 
     def initialize(self):

--- a/commands/climber/moveclimber.py
+++ b/commands/climber/moveclimber.py
@@ -5,26 +5,6 @@ from ultime.autoproperty import autoproperty
 from ultime.command import Command
 
 
-class MoveClimber:
-    @staticmethod
-    def toReadyPosition(climber: Climber):
-        cmd = ReadyClimber(climber)
-        cmd.setName(MoveClimber.__name__ + ".toReadyPosition")
-        return cmd
-
-    @staticmethod
-    def toClimbedPosition(climber: Climber):
-        cmd = ClimbClimber(climber)
-        cmd.setName(MoveClimber.__name__ + ".toClimbedPosition")
-        return cmd
-
-    @staticmethod
-    def toInitialPosition(climber: Climber):
-        cmd = ReleaseClimber(climber)
-        cmd.setName(MoveClimber.__name__ + ".toInitialPosition")
-        return cmd
-
-
 class MovingClimber(Command):
     def __init__(self, climber: Climber, state: Climber.State):
         super().__init__()

--- a/modules/dashboard.py
+++ b/modules/dashboard.py
@@ -71,7 +71,6 @@ class DashboardModule(Module):
         """
         Climber
         """
-
         putCommandOnDashboard("Climber", ReadyClimber(hardware.climber))
         putCommandOnDashboard("Climber", Climb(hardware.climber))
         putCommandOnDashboard("Climber", ReleaseClimber(hardware.climber))

--- a/modules/dashboard.py
+++ b/modules/dashboard.py
@@ -4,7 +4,7 @@ import wpilib
 from commands.arm.extendarm import ExtendArm
 from commands.arm.retractarm import RetractArm
 from commands.claw.drop import Drop
-from commands.climber.moveclimber import ClimbClimber, ReadyClimber, ReleaseClimber
+from commands.climber.moveclimber import Climb, ReadyClimber, ReleaseClimber
 from commands.elevator.maintainelevator import MaintainElevator
 from commands.elevator.manualmoveelevator import ManualMoveElevator
 from commands.elevator.moveelevator import MoveElevator
@@ -38,8 +38,12 @@ class DashboardModule(Module):
         putCommandOnDashboard("Arm", RetractArm(hardware.arm))
         putCommandOnDashboard("Arm", ExtendArm(hardware.arm))
 
+        """
+        Climber
+        """
+
         putCommandOnDashboard("Climber", ReadyClimber(hardware.climber))
-        putCommandOnDashboard("Climber", ClimbClimber(hardware.climber))
+        putCommandOnDashboard("Climber", Climb(hardware.climber))
         putCommandOnDashboard("Climber", ReleaseClimber(hardware.climber))
 
     def robotInit(self) -> None:

--- a/modules/dashboard.py
+++ b/modules/dashboard.py
@@ -4,7 +4,7 @@ import wpilib
 from commands.arm.extendarm import ExtendArm
 from commands.arm.retractarm import RetractArm
 from commands.claw.drop import Drop
-from commands.climber.moveclimber import MoveClimber
+from commands.climber.moveclimber import ClimbClimber, ReadyClimber, ReleaseClimber
 from commands.elevator.maintainelevator import MaintainElevator
 from commands.elevator.manualmoveelevator import ManualMoveElevator
 from commands.elevator.moveelevator import MoveElevator
@@ -38,13 +38,9 @@ class DashboardModule(Module):
         putCommandOnDashboard("Arm", RetractArm(hardware.arm))
         putCommandOnDashboard("Arm", ExtendArm(hardware.arm))
 
-        putCommandOnDashboard(
-            "Climber", MoveClimber.toInitialPosition(hardware.climber)
-        )
-        putCommandOnDashboard("Climber", MoveClimber.toReadyPosition(hardware.climber))
-        putCommandOnDashboard(
-            "Climber", MoveClimber.toClimbedPosition(hardware.climber)
-        )
+        putCommandOnDashboard("Climber", ReadyClimber(hardware.climber))
+        putCommandOnDashboard("Climber", ClimbClimber(hardware.climber))
+        putCommandOnDashboard("Climber", ReleaseClimber(hardware.climber))
 
     def robotInit(self) -> None:
         for subsystem in self._hardware.subsystems:

--- a/modules/hardware.py
+++ b/modules/hardware.py
@@ -5,6 +5,7 @@ from commands.claw.loadcoral import LoadCoral
 from commands.elevator.maintainelevator import MaintainElevator
 from subsystems.arm import Arm
 from subsystems.claw import Claw
+from subsystems.climber import Climber
 from subsystems.drivetrain import Drivetrain
 from subsystems.elevator import Elevator
 from subsystems.printer import Printer
@@ -27,6 +28,8 @@ class HardwareModule(Module):
 
         self.printer = Printer()
 
+        self.climber = Climber()
+
         self.controller = commands2.button.CommandXboxController(0)
 
         self.subsystems: list[Subsystem] = [
@@ -35,4 +38,5 @@ class HardwareModule(Module):
             self.claw,
             self.arm,
             self.printer,
+            self.climber,
         ]

--- a/ports.py
+++ b/ports.py
@@ -22,6 +22,7 @@ class CAN(Immutable):
     drivetrain_motor_turning_fr = 7
     drivetrain_motor_driving_fr = 8
     elevator_motor = 9
+    climber_motor = 10
 
 
 class PWM(Immutable):
@@ -39,6 +40,7 @@ class DIO:
     printer_encoder_b = 4
     printer_photocell = 5
     claw_photocell = 6
+    climber_switch = 7
 
 
 class PDP:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.robotpy]
 
 # Version of robotpy this project depends on
-robotpy_version = "2025.2.1.1"
+robotpy_version = "2025.2.1.2"
 
 robotpy_extras = [
     "apriltag",

--- a/subsystems/climber.py
+++ b/subsystems/climber.py
@@ -13,7 +13,7 @@ from ultime.switch import Switch
 
 class Climber(Subsystem):
     class State(Enum):
-        Invalid = auto()
+        Unknown = auto()
         Moving = auto()
         Initial = auto()
         Ready = auto()
@@ -56,9 +56,7 @@ class Climber(Subsystem):
             self._switch.setSimUnpressed()
 
     def isInitial(self):
-        if self.state == self.State.Initial:
-            return True
-        return False
+        return self.state == self.State.Initial
 
     def isClimbed(self):
         return self._switch.isPressed()

--- a/tests/test_climber.py
+++ b/tests/test_climber.py
@@ -1,7 +1,7 @@
 from _pytest.python_api import approx
 from rev import SparkBase, SparkBaseConfig
 
-from commands.climber.moveclimber import MoveClimber
+from commands.climber.moveclimber import ReadyClimber, ReleaseClimber, ClimbClimber
 from robot import Robot
 from ultime.switch import Switch
 from ultime.tests import RobotTestController
@@ -36,7 +36,7 @@ def test_climber_ready(robot_controller: RobotTestController, robot: Robot):
     climber = robot.hardware.climber
     robot_controller.startTeleop()
 
-    cmd = MoveClimber.toReadyPosition(climber)
+    cmd = ReadyClimber(climber)
     cmd.schedule()
 
     robot_controller.wait(0.5)
@@ -54,7 +54,7 @@ def test_climber_climbed(robot_controller: RobotTestController, robot: Robot):
     climber = robot.hardware.climber
     robot_controller.startTeleop()
 
-    cmd = MoveClimber.toClimbedPosition(climber)
+    cmd = ClimbClimber(climber)
     cmd.schedule()
 
     robot_controller.wait(0.5)
@@ -73,14 +73,14 @@ def test_climber_initial(robot_controller: RobotTestController, robot: Robot):
     climber = robot.hardware.climber
     robot_controller.startTeleop()
 
-    cmd = MoveClimber.toClimbedPosition(climber)
+    cmd = ClimbClimber(climber)
     cmd.schedule()
 
     robot_controller.wait(20)
 
     assert climber.state == climber.State.Climbed
 
-    cmd = MoveClimber.toInitialPosition(climber)
+    cmd = ReleaseClimber(climber)
     cmd.schedule()
 
     robot_controller.wait(0.5)

--- a/tests/test_climber.py
+++ b/tests/test_climber.py
@@ -90,4 +90,4 @@ def test_climber_initial(robot_controller: RobotTestController, robot: Robot):
     robot_controller.wait(20)
 
     assert climber._motor.get() == approx(0.0, abs=0.1)
-    assert climber.state == climber.State.Initial
+    assert climber.isInitial()

--- a/tests/test_climber.py
+++ b/tests/test_climber.py
@@ -11,7 +11,7 @@ def test_ports(robot: Robot):
     climber = robot.hardware.climber
 
     assert climber._motor.getDeviceId() == 10
-    assert climber._switch.getChannel() == 1
+    assert climber._switch.getChannel() == 7
 
 
 def test_settings(robot: Robot):

--- a/tests/test_climber.py
+++ b/tests/test_climber.py
@@ -1,7 +1,7 @@
 from _pytest.python_api import approx
 from rev import SparkBase, SparkBaseConfig
 
-from commands.climber.moveclimber import ReadyClimber, ReleaseClimber, ClimbClimber
+from commands.climber.moveclimber import ReadyClimber, ReleaseClimber, Climb
 from robot import Robot
 from ultime.switch import Switch
 from ultime.tests import RobotTestController
@@ -54,7 +54,7 @@ def test_climber_climbed(robot_controller: RobotTestController, robot: Robot):
     climber = robot.hardware.climber
     robot_controller.startTeleop()
 
-    cmd = ClimbClimber(climber)
+    cmd = Climb(climber)
     cmd.schedule()
 
     robot_controller.wait(0.5)
@@ -73,7 +73,7 @@ def test_climber_initial(robot_controller: RobotTestController, robot: Robot):
     climber = robot.hardware.climber
     robot_controller.startTeleop()
 
-    cmd = ClimbClimber(climber)
+    cmd = Climb(climber)
     cmd.schedule()
 
     robot_controller.wait(20)


### PR DESCRIPTION
# Description
<!--- Fais un résumé de ce que tu as ajouté. -->
Closes #56 . 

### Vérifications générales
- [x] Code en anglais
- [x] Noms de fichier en lettres minuscules et sans espace
- [x] Noms de classe en `PascalCase`
- [x] Noms de fonction en `camelCase`
- [x] Noms de variables en `snake_case`
- [x] Noms de fonction débutent par un verbe d'action (get, set, move, start,
  stop...)
- Ports
  - [x] se trouvent dans `ports.py`
  - [x] respectent la convention `subsystem_composante_precision` (p. ex. 
    `shooter_motor_left`)
- [x] Chaque `autoproperty` respecte la convention `type_precision` (p.ex. 
  `speed_slow`, `height_max`, `distance_max`)
- [x] Tests unitaires pour maintenir ou augmenter la couverture
- [x] Chaque dossier est un module (contient `__init__.py`)

### Command
- [x] Nom débute par un verbe d'action
- [x] Ajoutée sur le Dashboard
- [x] Ses paramètres sont dans des `autoproperty`
- [x] Si pertinent (calculs), implémente `initSendable` pour afficher toute 
  information pertinente sur son état

### Subsystem
- [x] Hérite de la classe `ultime.Subsystem` (et non `commands2.
Subsystem`)
- [x] Ses composantes ont été liées au sous-système par `self.addChild()`
- [x] Ses paramètres sont dans des `autoproperty`
- [x] Implémente `initSendable` pour afficher toute information pertinente 
  sur son état
- [x] Instancié et ajouté sur le Dashboard

