### PR TITLE
63 timeout commands elevator

### DIFF
--- a/commands/elevator/moveelevator.py
+++ b/commands/elevator/moveelevator.py
@@ -6,7 +6,7 @@ from ultime.command import Command, with_timeout
 from ultime.trapezoidalmotion import TrapezoidalMotion
 
 
-@with_timeout(5.0)
+@with_timeout(10.0)
 class MoveElevator(Command):
     @classmethod
     def toLevel1(cls, elevator: Elevator):

--- a/commands/elevator/moveelevator.py
+++ b/commands/elevator/moveelevator.py
@@ -2,10 +2,11 @@ import wpilib
 
 from subsystems.elevator import Elevator
 from ultime.autoproperty import autoproperty, FloatProperty, asCallable
-from ultime.command import Command
+from ultime.command import Command, with_timeout
 from ultime.trapezoidalmotion import TrapezoidalMotion
 
 
+@with_timeout(5.0)
 class MoveElevator(Command):
     @classmethod
     def toLevel1(cls, elevator: Elevator):

--- a/commands/elevator/resetelevator.py
+++ b/commands/elevator/resetelevator.py
@@ -1,7 +1,8 @@
 from subsystems.elevator import Elevator
-from ultime.command import Command
+from ultime.command import Command, with_timeout
 
 
+@with_timeout(5.0)
 class ResetElevator(Command):
     def __init__(self, elevator: Elevator):
         super().__init__()

--- a/commands/elevator/resetelevator.py
+++ b/commands/elevator/resetelevator.py
@@ -2,7 +2,7 @@ from subsystems.elevator import Elevator
 from ultime.command import Command, with_timeout
 
 
-@with_timeout(5.0)
+@with_timeout(10.0)
 class ResetElevator(Command):
     def __init__(self, elevator: Elevator):
         super().__init__()

--- a/subsystems/elevator.py
+++ b/subsystems/elevator.py
@@ -72,7 +72,7 @@ class Elevator(Subsystem):
         else:
             gravity = 0.0
 
-        distance = (self._motor.get() - gravity) * 0.011
+        distance = (self._motor.get() - gravity) * 0.031
 
         self._sim_height += distance
         self._sim_encoder.setPosition(self._sim_encoder.getPosition() + distance)

--- a/ultime/command.py
+++ b/ultime/command.py
@@ -12,6 +12,7 @@ def ignore_requirements(reqs: list[str]):
 
     return _ignore
 
+
 def with_timeout(seconds: float, print_error=True):
     def add_timeout(CommandClass):
         class CommandWithTimeout(CommandClass):

--- a/ultime/command.py
+++ b/ultime/command.py
@@ -1,7 +1,7 @@
 from typing import Type
 
 import wpilib
-from commands2 import Command, ParallelRaceGroup, WaitCommand
+from commands2 import Command
 from wpilib import Timer
 
 
@@ -11,25 +11,6 @@ def ignore_requirements(reqs: list[str]):
         return actual_cls
 
     return _ignore
-
-
-class WaitCommandError(Command):
-    def __init__(self, seconds: float, cmd: Command):
-        super().__init__()
-        self.seconds = seconds
-        self.cmd = cmd
-        self.timer = Timer()
-
-    def initialize(self):
-        self.timer.restart()
-
-    def isFinished(self) -> bool:
-        return self.timer.get() >= self.seconds
-
-    def end(self, interrupted: bool):
-        if not interrupted:
-            wpilib.reportError(f"Command {self.cmd.getName()} got interrupted after {self.seconds} seconds")
-
 
 def with_timeout(seconds: float, print_error=True):
     def add_timeout(CommandClass):
@@ -51,7 +32,9 @@ def with_timeout(seconds: float, print_error=True):
                 super().end(interrupted)
                 self.timer.stop()
                 if self.timer.get() >= self.seconds:
-                    wpilib.reportError(f"Command {self.getName()} got interrupted after {self.seconds} seconds")
+                    wpilib.reportError(
+                        f"Command {self.getName()} got interrupted after {self.seconds} seconds"
+                    )
 
         return CommandWithTimeout
 

--- a/ultime/command.py
+++ b/ultime/command.py
@@ -2,7 +2,7 @@ from typing import Type
 
 import wpilib
 from commands2 import Command
-from wpilib import Timer
+from wpilib import Timer, DataLogManager
 
 
 def ignore_requirements(reqs: list[str]):
@@ -13,7 +13,7 @@ def ignore_requirements(reqs: list[str]):
     return _ignore
 
 
-def with_timeout(seconds: float, print_error=True):
+def with_timeout(seconds: float):
     def add_timeout(CommandClass):
         class CommandWithTimeout(CommandClass):
             def __init__(self, *args, **kwargs):
@@ -33,9 +33,9 @@ def with_timeout(seconds: float, print_error=True):
                 super().end(interrupted)
                 self.timer.stop()
                 if self.timer.get() >= self.seconds:
-                    wpilib.reportError(
-                        f"Command {self.getName()} got interrupted after {self.seconds} seconds"
-                    )
+                    msg = f"Command {self.getName()} got interrupted after {self.seconds} seconds"
+                    wpilib.reportError(msg)
+                    DataLogManager.log(msg)
 
         return CommandWithTimeout
 

--- a/ultime/command.py
+++ b/ultime/command.py
@@ -1,6 +1,8 @@
 from typing import Type
 
-from commands2 import Command
+import wpilib
+from commands2 import Command, ParallelRaceGroup, WaitCommand
+from wpilib import Timer
 
 
 def ignore_requirements(reqs: list[str]):
@@ -9,3 +11,48 @@ def ignore_requirements(reqs: list[str]):
         return actual_cls
 
     return _ignore
+
+
+class WaitCommandError(Command):
+    def __init__(self, seconds: float, cmd: Command):
+        super().__init__()
+        self.seconds = seconds
+        self.cmd = cmd
+        self.timer = Timer()
+
+    def initialize(self):
+        self.timer.restart()
+
+    def isFinished(self) -> bool:
+        return self.timer.get() >= self.seconds
+
+    def end(self, interrupted: bool):
+        if not interrupted:
+            wpilib.reportError(f"Command {self.cmd.getName()} got interrupted after {self.seconds} seconds")
+
+
+def with_timeout(seconds: float, print_error=True):
+    def add_timeout(CommandClass):
+        class CommandWithTimeout(CommandClass):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.setName(CommandClass.__name__)
+                self.seconds = seconds
+                self.timer = Timer()
+
+            def initialize(self):
+                super().initialize()
+                self.timer.restart()
+
+            def isFinished(self) -> bool:
+                return super().isFinished() or self.timer.get() >= self.seconds
+
+            def end(self, interrupted: bool):
+                super().end(interrupted)
+                self.timer.stop()
+                if self.timer.get() >= self.seconds:
+                    wpilib.reportError(f"Command {self.getName()} got interrupted after {self.seconds} seconds")
+
+        return CommandWithTimeout
+
+    return add_timeout

--- a/ultime/tests/test_commands.py
+++ b/ultime/tests/test_commands.py
@@ -23,6 +23,9 @@ def get_commands() -> List[Type[Command]]:
                 and not cls.__module__.startswith("commands2")
                 and cls not in cmds
             ):
+                if cls.__name__ == "CommandWithTimeout":
+                    cls = cls.mro()[1]
+
                 cmds.append(cls)
     return cmds
 


### PR DESCRIPTION
# Description
<!--- Fais un résumé de ce que tu as ajouté. -->
Closes #63 . 

### Vérifications générales
- [x] Code en anglais
- [x] Noms de fichier en lettres minuscules et sans espace
- [x] Noms de classe en `PascalCase`
- [x] Noms de fonction en `camelCase`
- [x] Noms de variables en `snake_case`
- [x] Noms de fonction débutent par un verbe d'action (get, set, move, start,
  stop...)
- Ports
  - [x] se trouvent dans `ports.py`
  - [x] respectent la convention `subsystem_composante_precision` (p. ex. 
    `shooter_motor_left`)
- [x] Chaque `autoproperty` respecte la convention `type_precision` (p.ex. 
  `speed_slow`, `height_max`, `distance_max`)
- [x] Tests unitaires pour maintenir ou augmenter la couverture
- [x] Chaque dossier est un module (contient `__init__.py`)

### Command
- [x] Nom débute par un verbe d'action
- [x] Ajoutée sur le Dashboard
- [x] Ses paramètres sont dans des `autoproperty`
- [x] Si pertinent (calculs), implémente `initSendable` pour afficher toute 
  information pertinente sur son état

### Subsystem
- [x] Hérite de la classe `ultime.Subsystem` (et non `commands2.
Subsystem`)
- [x] Ses composantes ont été liées au sous-système par `self.addChild()`
- [x] Ses paramètres sont dans des `autoproperty`
- [x] Implémente `initSendable` pour afficher toute information pertinente 
  sur son état
- [x] Instancié et ajouté sur le Dashboard

