### PR TITLE
change grab_switch to analog sensor

### DIFF
--- a/commands/intake/dropalgae.py
+++ b/commands/intake/dropalgae.py
@@ -14,7 +14,7 @@ class DropAlgae(SequentialCommandGroup):
 
 
 class _DropAlgae(Command):
-    delay = autoproperty(3.0)
+    delay = autoproperty(1.0)
 
     def __init__(self, intake: Intake):
         super().__init__()

--- a/ports.py
+++ b/ports.py
@@ -52,7 +52,7 @@ class DIO:
 
     intake_encoder_a = 7
     intake_encoder_b = 8
-    intake_switch_grab = 10
+    intake_switch_pivot = 10
 
     climber_switch = 9
 

--- a/ports.py
+++ b/ports.py
@@ -59,5 +59,6 @@ class DIO:
 class PDP:
     pass
 
+
 class Analog:
     intake_grab_sensor = 0

--- a/ports.py
+++ b/ports.py
@@ -50,3 +50,6 @@ class DIO:
 
 class PDP:
     pass
+
+class Analog:
+    intake_grab_sensor = 0

--- a/ports.py
+++ b/ports.py
@@ -39,21 +39,23 @@ class PWM(Immutable):
 
 
 class DIO:
-    elevator_switch = 6
-
-    printer_switch_right = 3
-    printer_switch_left = 2
     printer_encoder_a = 0
     printer_encoder_b = 1
+    printer_switch_left = 2
+    printer_switch_right = 3
 
     printer_photocell = 4
+
     claw_photocell = 5
 
-    climber_switch = 9
+    elevator_switch = 6
 
-    intake_switch_grab = 10
     intake_encoder_a = 7
     intake_encoder_b = 8
+    intake_switch_grab = 10
+    intake_switch_pivot = 11
+
+    climber_switch = 9
 
 
 class PDP:

--- a/subsystems/intake.py
+++ b/subsystems/intake.py
@@ -54,7 +54,8 @@ class Intake(Subsystem):
             self._sim_grab_motor = PWMSim(self._grab_motor)
             self._sim_pivot_motor = PWMSim(self._pivot_motor)
             self._sim_encoder = EncoderSim(self._pivot_encoder)
-            self._sim_pos = 0.3
+            self._sim_pos_initial = 0.3
+            self._sim_pos = self._sim_pos_initial
             self._sim_grab_sensor = AnalogInputSim(self._grab_sensor)
 
     def periodic(self) -> None:
@@ -64,13 +65,12 @@ class Intake(Subsystem):
         self._prev_is_retracted = self.isRetracted()
 
     def simulationPeriodic(self) -> None:
-        distance = self._pivot_motor.get()
+        distance = self._pivot_motor.get() * 3
 
         self._sim_pos += distance
         self._sim_encoder.setCount(
             int(
-                self._sim_encoder.getCount()
-                + distance / self.position_conversion_factor
+                (self._sim_pos - self._sim_pos_initial) / self.position_conversion_factor
             )
         )
 
@@ -131,7 +131,7 @@ class Intake(Subsystem):
         builder.addStringProperty("state", lambda: self.state.name, noop)
         builder.addFloatProperty("pivot_motor_input", self._pivot_motor.get, noop)
         builder.addFloatProperty("grab_motor_input", self._grab_motor.get, noop)
-        builder.addFloatProperty("pivot_encoder", self._pivot_encoder.getDistance, noop)
+        builder.addFloatProperty("pivot_encoder", self._pivot_encoder.get, noop)
         builder.addFloatProperty("offset", lambda: self._offset, lambda x: setOffset(x))
         builder.addFloatProperty("pivot_position", self.getPivotPosition, noop)
         builder.addBooleanProperty("has_reset", lambda: self._has_reset, setHasReset)

--- a/subsystems/intake.py
+++ b/subsystems/intake.py
@@ -70,7 +70,8 @@ class Intake(Subsystem):
         self._sim_pos += distance
         self._sim_encoder.setCount(
             int(
-                (self._sim_pos - self._sim_pos_initial) / self.position_conversion_factor
+                (self._sim_pos - self._sim_pos_initial)
+                / self.position_conversion_factor
             )
         )
 

--- a/subsystems/intake.py
+++ b/subsystems/intake.py
@@ -1,8 +1,7 @@
 from enum import Enum, auto
-from operator import truediv
 
 import wpilib
-from wpilib import VictorSP, Encoder, RobotBase, AnalogInput
+from wpilib import VictorSP, RobotBase
 from wpilib.simulation import PWMSim, EncoderSim, AnalogInputSim
 from wpiutil import SendableBuilder
 
@@ -33,9 +32,6 @@ class Intake(Subsystem):
             ports.DIO.intake_encoder_a,
             ports.DIO.intake_encoder_b,
             reverseDirection=False,
-        )
-        self._pivot_switch = Switch(
-            Switch.Type.NormallyOpen, ports.DIO.intake_switch_pivot
         )
 
         self._pivot_encoder.setDistancePerPulse(self.position_conversion_factor)
@@ -141,6 +137,8 @@ class Intake(Subsystem):
         builder.addBooleanProperty("has_reset", lambda: self._has_reset, setHasReset)
         builder.addBooleanProperty("hasAlgae", self.hasAlgae, noop)
         builder.addFloatProperty("grab_voltage", self._grab_sensor.getVoltage, noop)
-        builder.addFloatProperty("grab_voltage_average", self._grab_sensor.getAverageVoltage, noop)
+        builder.addFloatProperty(
+            "grab_voltage_average", self._grab_sensor.getAverageVoltage, noop
+        )
         builder.addBooleanProperty("pivot_switch", self._pivot_switch.isPressed, noop)
         builder.addBooleanProperty("isRetracted", self.isRetracted, noop)

--- a/subsystems/intake.py
+++ b/subsystems/intake.py
@@ -34,7 +34,9 @@ class Intake(Subsystem):
             ports.DIO.intake_encoder_b,
             reverseDirection=False,
         )
-        self._pivot_switch = Switch(switch_type=Switch.Type.AlwaysUnpressed)
+        self._pivot_switch = Switch(
+            Switch.Type.NormallyOpen, ports.DIO.intake_switch_pivot
+        )
 
         self._grab_motor = VictorSP(ports.PWM.intake_motor_grab)
         self._grab_sensor = wpilib.AnalogInput(ports.Analog.intake_grab_sensor)
@@ -43,7 +45,7 @@ class Intake(Subsystem):
         self.addChild("grab_motor", self._grab_motor)
         self.addChild("pivot_encoder", self._pivot_encoder)
 
-        self._has_reset = True
+        self._has_reset = False
         self._prev_is_retracted = False
         self._offset = 0.0
 
@@ -105,7 +107,7 @@ class Intake(Subsystem):
         return self._pivot_switch.isPressed()
 
     def hasAlgae(self):
-        return self._grab_sensor.getValue() >= self.threshold_grab
+        return self._grab_sensor.getVoltage() >= self.threshold_grab
 
     def getPivotMotorInput(self):
         return self._pivot_motor.get()
@@ -132,6 +134,8 @@ class Intake(Subsystem):
         builder.addFloatProperty("offset", lambda: self._offset, lambda x: setOffset(x))
         builder.addFloatProperty("pivot_position", self.getPivotPosition, noop)
         builder.addBooleanProperty("has_reset", lambda: self._has_reset, setHasReset)
-        builder.addBooleanProperty("has_algae", self.hasAlgae, noop)
+        builder.addBooleanProperty("hasAlgae", self.hasAlgae, noop)
+        builder.addFloatProperty("grab_voltage", self._grab_sensor.getVoltage, noop)
+        builder.addFloatProperty("grab_voltage_average", self._grab_sensor.getAverageVoltage, noop)
         builder.addBooleanProperty("pivot_switch", self._pivot_switch.isPressed, noop)
         builder.addBooleanProperty("isRetracted", self.isRetracted, noop)

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -21,7 +21,7 @@ def test_ports(robot: Robot):
     assert intake._grab_motor.getChannel() == 4
     assert intake._pivot_motor.getChannel() == 5
 
-    assert intake._grab_switch.getChannel() == 8
+    assert intake._grab_sensor.getChannel() == 0
 
 
 def test_settings(robot: Robot):
@@ -30,8 +30,6 @@ def test_settings(robot: Robot):
     assert intake._pivot_switch.getType() == Switch.Type.AlwaysUnpressed
 
     assert not intake._pivot_motor.getInverted()
-
-    assert intake._grab_switch.getType() == Switch.Type.NormallyOpen
 
     assert not intake._grab_motor.getInverted()
 
@@ -49,7 +47,7 @@ def test_grab_algae(robot_controller: RobotTestController, robot: Robot):
 
     intake._has_reset = True
     intake._sim_encoder.setDistance(0)
-    intake._grab_switch.setSimUnpressed()
+    intake._sim_grab_sensor.setVoltage(0)
 
     cmd = GrabAlgae(robot.hardware.intake)
     cmd.schedule()
@@ -66,7 +64,7 @@ def test_grab_algae(robot_controller: RobotTestController, robot: Robot):
     assert intake._grab_motor.get() == approx(intake.grab_speed, rel=0.1)
     assert intake._pivot_motor.get() == 0.0
 
-    intake._grab_switch.setSimPressed()
+    intake._sim_grab_sensor.setVoltage(5)
 
     wait(0.5)
 
@@ -86,7 +84,7 @@ def test_drop_algae(robot_controller: RobotTestController, robot: Robot):
 
     # actual test
     robot_controller.startTeleop()
-    intake._grab_switch.setSimPressed()
+    intake._sim_grab_sensor.setVoltage(5)
     intake._sim_encoder.setDistance(50)
     intake._has_reset = True
 
@@ -100,7 +98,7 @@ def test_drop_algae(robot_controller: RobotTestController, robot: Robot):
     assert intake._grab_motor.get() == approx((-1 * intake.grab_speed), rel=0.1)
     assert intake._pivot_motor.get() == 0.0
 
-    intake._grab_switch.setSimUnpressed()
+    intake._sim_grab_sensor.setVoltage(0)
 
     wait(1.5)
 

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -84,13 +84,13 @@ def test_drop_algae(robot_controller: RobotTestController, robot: Robot):
     intake._sim_grab_sensor.setVoltage(5)
     intake._sim_encoder.setDistance(50)
     intake._has_reset = True
-    intake._grab_switch.setSimUnpressed()
+    intake._sim_grab_sensor.setVoltage(0)
 
     cmd = GrabAlgae(robot.hardware.intake)
     cmd.schedule()
 
     wait(10.0)
-    intake._grab_switch.setSimPressed()
+    intake._sim_grab_sensor.setVoltage(5)
     wait(10.0)
 
     assert not cmd.isScheduled()

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -48,7 +48,7 @@ def test_grab_algae(robot_controller: RobotTestController, robot: Robot):
     cmd = GrabAlgae(robot.hardware.intake)
     cmd.schedule()
 
-    wait(1)
+    wait(0.05)
 
     assert intake._grab_motor.get() == approx(0.0)
     assert intake._pivot_motor.get() >= move_intake_properties.speed_min

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -62,7 +62,7 @@ def test_grab_algae(robot_controller: RobotTestController, robot: Robot):
     assert intake._grab_motor.get() == approx(intake.grab_speed, rel=0.1)
     assert intake._pivot_motor.get() == 0.0
 
-    intake._sim_grab_sensor.setVoltage(5)
+    intake._sim_grab_sensor.setVoltage(intake.threshold_grab + 1)
 
     wait(0.5)
 
@@ -81,7 +81,7 @@ def test_drop_algae(robot_controller: RobotTestController, robot: Robot):
     intake = robot.hardware.intake
 
     robot_controller.startTeleop()
-    intake._sim_grab_sensor.setVoltage(5)
+    intake._sim_grab_sensor.setVoltage(intake.threshold_grab + 1)
     intake._sim_encoder.setDistance(50)
     intake._has_reset = True
     intake._sim_grab_sensor.setVoltage(0)
@@ -90,7 +90,7 @@ def test_drop_algae(robot_controller: RobotTestController, robot: Robot):
     cmd.schedule()
 
     wait(10.0)
-    intake._sim_grab_sensor.setVoltage(5)
+    intake._sim_grab_sensor.setVoltage(intake.threshold_grab + 1)
     wait(10.0)
 
     assert not cmd.isScheduled()

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -1,4 +1,3 @@
-import pytest
 from _pytest.python_api import approx
 
 from commands.intake.dropalgae import DropAlgae

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -134,7 +134,6 @@ def test_moveElevator_toMiddle(robot_controller: RobotTestController, robot: Rob
     )
 
 
-@pytest.mark.specific
 def test_movePrinter_toLoading(robot_controller: RobotTestController, robot: Robot):
     robot_controller.startTeleop()
 
@@ -199,7 +198,6 @@ def test_movePrinter_toRight(robot_controller: RobotTestController, robot: Robot
     assert robot.hardware.printer.getPosition() == approx(0.0, abs=0.005)
 
 
-@pytest.mark.specific
 def test_move_printer_leftUntilReef(
     robot_controller: RobotTestController, robot: Robot
 ):
@@ -238,7 +236,6 @@ def test_move_printer_leftUntilReef(
     assert robot.hardware.printer._motor.get() == approx(0.0)
 
 
-@pytest.mark.specific
 def test_move_printer_rightUntilReef(
     robot_controller: RobotTestController, robot: Robot
 ):

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -1,4 +1,3 @@
-import pytest
 from _pytest.python_api import approx
 from wpilib.simulation import stepTiming
 


### PR DESCRIPTION
# Description
<!--- Fais un résumé de ce que tu as ajouté. --> 
Changed intake limit switch to be an analog sensor.
Closes #79. 

### Vérifications générales
- [x] Code en anglais
- [x] Noms de fichier en lettres minuscules et sans espace
- [x] Noms de classe en `PascalCase`
- [x] Noms de fonction en `camelCase`
- [x] Noms de variables en `snake_case`
- [x] Noms de fonction débutent par un verbe d'action (get, set, move, start,
  stop...)
- Ports
  - [x] se trouvent dans `ports.py`
  - [x] respectent la convention `subsystem_composante_precision` (p. ex. 
    `shooter_motor_left`)
- [x] Chaque `autoproperty` respecte la convention `type_precision` (p.ex. 
  `speed_slow`, `height_max`, `distance_max`)
- [x] Tests unitaires pour maintenir ou augmenter la couverture
- [x] Chaque dossier est un module (contient `__init__.py`)

### Command
- [x] Nom débute par un verbe d'action
- [x] Ajoutée sur le Dashboard
- [x] Ses paramètres sont dans des `autoproperty`
- [x] Si pertinent (calculs), implémente `initSendable` pour afficher toute 
  information pertinente sur son état

### Subsystem
- [x] Hérite de la classe `ultime.Subsystem` (et non `commands2.
Subsystem`)
- [x] Ses composantes ont été liées au sous-système par `self.addChild()`
- [x] Ses paramètres sont dans des `autoproperty`
- [x] Implémente `initSendable` pour afficher toute information pertinente 
  sur son état
- [x] Instancié et ajouté sur le Dashboard

