### PR TITLE
Added ResetAutonomous

### DIFF
--- a/commands/resetautonomous.py
+++ b/commands/resetautonomous.py
@@ -1,0 +1,28 @@
+from commands2 import ParallelCommandGroup, InstantCommand
+
+from commands.printer.resetprinter import ResetPrinterRight
+from subsystems.arm import Arm
+from subsystems.elevator import Elevator
+from subsystems.intake import Intake
+from subsystems.printer import Printer
+from subsystems.climber import Climber
+from ultime.command import ignore_requirements
+
+
+@ignore_requirements(["elevator", "printer", "arm", "intake", "climber"])
+class ResetAutonomous(ParallelCommandGroup):
+    def __init__(
+        self,
+        elevator: Elevator,
+        printer: Printer,
+        arm: Arm,
+        intake: Intake,
+        climber: Climber,
+    ):
+        super().__init__(
+            InstantCommand(lambda: elevator.setReset()),
+            InstantCommand(lambda: intake.setReset()),
+            InstantCommand(lambda: arm.setReset()),
+            InstantCommand(lambda: climber.setReset()),
+            ResetPrinterRight(printer),
+        )

--- a/commands/resetautonomous.py
+++ b/commands/resetautonomous.py
@@ -1,11 +1,10 @@
 from commands2 import ParallelCommandGroup, InstantCommand
 
+from commands.elevator.resetelevator import ResetElevator
 from commands.printer.resetprinter import ResetPrinterRight
 from subsystems.arm import Arm
 from subsystems.elevator import Elevator
-from subsystems.intake import Intake
 from subsystems.printer import Printer
-from subsystems.climber import Climber
 from ultime.command import ignore_requirements
 
 
@@ -16,13 +15,9 @@ class ResetAutonomous(ParallelCommandGroup):
         elevator: Elevator,
         printer: Printer,
         arm: Arm,
-        intake: Intake,
-        climber: Climber,
     ):
         super().__init__(
-            InstantCommand(lambda: elevator.setReset()),
-            InstantCommand(lambda: intake.setReset()),
             InstantCommand(lambda: arm.setReset()),
-            InstantCommand(lambda: climber.setReset()),
             ResetPrinterRight(printer),
+            ResetElevator(elevator),
         )

--- a/modules/autonomous.py
+++ b/modules/autonomous.py
@@ -12,6 +12,7 @@ from commands.arm.retractarm import RetractArm
 from commands.climber.resetclimber import ResetClimber
 from commands.dropprepareloading import DropPrepareLoading
 from commands.elevator.moveelevator import MoveElevator
+from commands.intake.resetintake import ResetIntake
 from commands.printer.moveprinter import MovePrinter
 from commands.resetall import ResetAll
 from commands.resetallbutclimber import ResetAllButClimber
@@ -55,6 +56,9 @@ class AutonomousModule(Module):
             True,
             lambda: False,  # Disable flipping, will be done by the command
         )
+
+        self.reset_climber_command = ResetClimber(self.hardware.climber)
+        self.reset_intake_command = ResetIntake(self.hardware.intake)
 
         self.setupCommandsOnPathPlanner()
 
@@ -111,6 +115,9 @@ class AutonomousModule(Module):
         )
 
     def autonomousInit(self):
+        self.reset_intake_command.schedule()
+        self.reset_climber_command.schedule()
+
         self.auto_command: commands2.Command = self.auto_chooser.getSelected()
         if self.auto_command:
             self.auto_command.schedule()

--- a/modules/dashboard.py
+++ b/modules/dashboard.py
@@ -156,9 +156,7 @@ class DashboardModule(Module):
             ResetAutonomous(
                 hardware.elevator,
                 hardware.printer,
-                hardware.arm,
-                hardware.intake,
-                hardware.climber,
+                hardware.arm
             ),
         )
 

--- a/modules/dashboard.py
+++ b/modules/dashboard.py
@@ -25,6 +25,7 @@ from commands.printer.resetprinter import ResetPrinterRight
 from commands.printer.scanprinter import ScanPrinter
 from commands.resetall import ResetAll
 from commands.resetallbutclimber import ResetAllButClimber
+from commands.resetautonomous import ResetAutonomous
 from modules.hardware import HardwareModule
 from ultime.module import Module, ModuleList
 
@@ -148,6 +149,16 @@ class DashboardModule(Module):
                 hardware.elevator,
                 hardware.drivetrain,
                 hardware.claw,
+            ),
+        )
+        putCommandOnDashboard(
+            "Group",
+            ResetAutonomous(
+                hardware.elevator,
+                hardware.printer,
+                hardware.arm,
+                hardware.intake,
+                hardware.climber,
             ),
         )
 

--- a/modules/dashboard.py
+++ b/modules/dashboard.py
@@ -153,11 +153,7 @@ class DashboardModule(Module):
         )
         putCommandOnDashboard(
             "Group",
-            ResetAutonomous(
-                hardware.elevator,
-                hardware.printer,
-                hardware.arm
-            ),
+            ResetAutonomous(hardware.elevator, hardware.printer, hardware.arm),
         )
 
     def robotInit(self) -> None:

--- a/subsystems/arm.py
+++ b/subsystems/arm.py
@@ -35,6 +35,10 @@ class Arm(Subsystem):
             AlertType.Error,
         )
 
+    def setReset(self):
+        self.state = self.State.Retracted
+        self.movement_state = self.MovementState.DoNotMove
+
     def extend(self):
         if self.movement_state == Arm.MovementState.DoNotMove:
             self.stop()

--- a/subsystems/climber.py
+++ b/subsystems/climber.py
@@ -51,6 +51,10 @@ class Climber(Subsystem):
             self._sim_motor = SparkMaxSim(self._motor, DCMotor.NEO(1))
             self._sim_encoder = self._sim_motor.getRelativeEncoderSim()
 
+    def setReset(self):
+        self._has_reset = True
+        self.state = self.State.Initial
+
     def periodic(self) -> None:
         if self._prev_is_down and not self._switch.isPressed():
             self._offset = (

--- a/subsystems/elevator.py
+++ b/subsystems/elevator.py
@@ -71,6 +71,11 @@ class Elevator(Subsystem):
     def getRawEncoderPosition(self):
         return self._encoder.getPosition()
 
+    def setReset(self):
+        self._has_reset = True
+        self.state = Elevator.State.Reset
+        self.movement_state = Elevator.MovementState.FreeToMove
+
     def periodic(self) -> None:
         if self._prev_is_down and not self._switch.isPressed():
             self._offset = self.height_min - self.getRawEncoderPosition()

--- a/subsystems/intake.py
+++ b/subsystems/intake.py
@@ -101,6 +101,10 @@ class Intake(Subsystem):
         else:
             self._pivot_switch.setSimUnpressed()
 
+    def setReset(self):
+        self._has_reset = True
+        self.state = self.State.Retracted
+
     def stopPivot(self):
         self._pivot_motor.stopMotor()
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,5 +1,3 @@
-import pytest
-
 from robot import Robot
 from ultime.tests import RobotTestController
 

--- a/tests/test_resetautonomous.py
+++ b/tests/test_resetautonomous.py
@@ -25,6 +25,7 @@ def test_resetautonomous(robot_controller: RobotTestController, robot: Robot):
     assert elevator.state == Elevator.State.Reset
     assert elevator.movement_state == Elevator.MovementState.FreeToMove
     assert printer.state == Printer.State.Reset
+    assert printer.movement_state == Printer.MovementState.FreeToMove
     assert arm.state == Arm.State.Retracted
     assert arm.movement_state == Arm.MovementState.DoNotMove
     assert robot.hardware.intake.state == robot.hardware.intake.State.Retracted

--- a/tests/test_resetautonomous.py
+++ b/tests/test_resetautonomous.py
@@ -2,22 +2,38 @@ from commands.dropprepareloading import DropPrepareLoading
 from commands.resetautonomous import ResetAutonomous
 from robot import Robot
 from subsystems.arm import Arm
+from subsystems.climber import Climber
 from subsystems.elevator import Elevator
+from subsystems.intake import Intake
 from subsystems.printer import Printer
 from ultime.tests import RobotTestController
 
 
 def test_resetautonomous(robot_controller: RobotTestController, robot: Robot):
-    robot_controller.startTeleop()
     elevator = robot.hardware.elevator
     printer = robot.hardware.printer
     arm = robot.hardware.arm
     drivetrain = robot.hardware.drivetrain
     claw = robot.hardware.claw
+    intake = robot.hardware.intake
+    climber = robot.hardware.climber
 
-    reset_cmd = ResetAutonomous(
-        elevator, printer, arm, robot.hardware.intake, robot.hardware.climber
+    # Testing if autonomousInit commands schedule properly
+    robot_controller.startAutonomous()
+    robot_controller.wait_until(
+        lambda: not robot.autonomous.reset_intake_command.isScheduled(), 10.0
     )
+    robot_controller.wait_until(
+        lambda: not robot.autonomous.reset_climber_command.isScheduled(), 10.0
+    )
+
+    assert intake.state == Intake.State.Retracted
+    assert climber.state == Climber.State.Initial
+
+    # ResetAutonomous Test
+    robot_controller.startTeleop()
+
+    reset_cmd = ResetAutonomous(elevator, printer, arm)
     reset_cmd.schedule()
 
     robot_controller.wait_until(lambda: not reset_cmd.isScheduled(), 10.0)
@@ -28,9 +44,8 @@ def test_resetautonomous(robot_controller: RobotTestController, robot: Robot):
     assert printer.movement_state == Printer.MovementState.FreeToMove
     assert arm.state == Arm.State.Retracted
     assert arm.movement_state == Arm.MovementState.DoNotMove
-    assert robot.hardware.intake.state == robot.hardware.intake.State.Retracted
-    assert robot.hardware.climber.state == robot.hardware.climber.State.Initial
 
+    # Make sure that the reset didn't disturb the normal functioning of the robot
     elevator.state = Elevator.State.Level3
     arm.state = Arm.State.Extended
 

--- a/tests/test_resetautonomous.py
+++ b/tests/test_resetautonomous.py
@@ -1,0 +1,45 @@
+from commands.dropprepareloading import DropPrepareLoading
+from commands.resetautonomous import ResetAutonomous
+from robot import Robot
+from subsystems.arm import Arm
+from subsystems.elevator import Elevator
+from subsystems.printer import Printer
+from ultime.tests import RobotTestController
+
+
+def test_resetautonomous(robot_controller: RobotTestController, robot: Robot):
+    robot_controller.startTeleop()
+    elevator = robot.hardware.elevator
+    printer = robot.hardware.printer
+    arm = robot.hardware.arm
+    drivetrain = robot.hardware.drivetrain
+    claw = robot.hardware.claw
+
+    reset_cmd = ResetAutonomous(
+        elevator, printer, arm, robot.hardware.intake, robot.hardware.climber
+    )
+    reset_cmd.schedule()
+
+    robot_controller.wait_until(lambda: not reset_cmd.isScheduled(), 10.0)
+
+    assert elevator.state == Elevator.State.Reset
+    assert elevator.movement_state == Elevator.MovementState.FreeToMove
+    assert printer.state == Printer.State.Reset
+    assert arm.state == Arm.State.Retracted
+    assert arm.movement_state == Arm.MovementState.DoNotMove
+    assert robot.hardware.intake.state == robot.hardware.intake.State.Retracted
+    assert robot.hardware.climber.state == robot.hardware.climber.State.Initial
+
+    elevator.state = Elevator.State.Level3
+    arm.state = Arm.State.Extended
+
+    cmd = DropPrepareLoading.toLeft(printer, arm, elevator, drivetrain, claw)
+    cmd.schedule()
+
+    robot_controller.wait(1.0)
+
+    robot_controller.wait_until(lambda: not cmd.isScheduled(), 10.0)
+
+    assert elevator.state == Elevator.State.Loading
+    assert printer.state == Printer.State.Loading
+    assert arm.state == arm.State.Retracted


### PR DESCRIPTION
# Description
Reset command for autonomous which takes for granted that the robot is in a known reset state. The only subsystem that is reset with a command is the printer because at the beginning of the autonomous mode it starts in the middle of its width.

Closes #152 . 

### Vérifications générales
- [x] Code en anglais
- [x] Noms de fichier en lettres minuscules et sans espace
- [x] Noms de classe en `PascalCase`
- [x] Noms de fonction en `camelCase`
- [x] Noms de variables en `snake_case`
- [x] Noms de fonction débutent par un verbe d'action (get, set, move, start,
  stop...)
- Ports
  - [x] se trouvent dans `ports.py`
  - [x] respectent la convention `subsystem_composante_precision` (p. ex. 
    `shooter_motor_left`)
- [x] Chaque `autoproperty` respecte la convention `type_precision` (p.ex. 
  `speed_slow`, `height_max`, `distance_max`)
- [x] Tests unitaires pour maintenir ou augmenter la couverture
- [x] Chaque dossier est un module (contient `__init__.py`)

### Command
- [x] Nom débute par un verbe d'action
- [x] Ajoutée sur le Dashboard
- [x] Ses paramètres sont dans des `autoproperty`
- [x] Si pertinent (calculs), implémente `initSendable` pour afficher toute 
  information pertinente sur son état

### Subsystem
- [x] Hérite de la classe `ultime.Subsystem` (et non `commands2.
Subsystem`)
- [x] Ses composantes ont été liées au sous-système par `self.addChild()`
- [x] Ses paramètres sont dans des `autoproperty`
- [x] Implémente `initSendable` pour afficher toute information pertinente 
  sur son état
- [x] Instancié et ajouté sur le Dashboard

