### PR TITLE
177 force printer right while loadcoral

### DIFF
--- a/commands/claw/loadcoral.py
+++ b/commands/claw/loadcoral.py
@@ -11,8 +11,7 @@ class LoadCoral(Command):
         super().__init__()
         self.claw = claw
         self.printer = printer
-        self.addRequirements(claw)
-        self.addRequirements(printer)
+        self.addRequirements(claw, printer)
         self.timer = wpilib.Timer()
         self.speed_left_claw = load_coral_properties.claw_speed_left
         self.speed_right_claw = load_coral_properties.claw_speed_right

--- a/commands/claw/loadcoral.py
+++ b/commands/claw/loadcoral.py
@@ -2,31 +2,39 @@ import wpilib
 from commands2 import Command
 
 from subsystems.claw import Claw
+from subsystems.printer import Printer
 from ultime.autoproperty import autoproperty
 
 
 class LoadCoral(Command):
-    def __init__(self, claw: Claw):
+    def __init__(self, claw: Claw, printer: Printer):
         super().__init__()
         self.claw = claw
+        self.printer = printer
         self.addRequirements(claw)
+        self.addRequirements(printer)
         self.timer = wpilib.Timer()
-        self.speed_left = load_coral_properties.speed_left
-        self.speed_right = load_coral_properties.speed_right
+        self.speed_left_claw = load_coral_properties.claw_speed_left
+        self.speed_right_claw = load_coral_properties.claw_speed_right
 
     def initialize(self):
         self.timer.stop()
         self.timer.reset()
 
     def execute(self):
-        self.claw.setLeft(self.speed_left)
-        self.claw.setRight(self.speed_right)
+        self.claw.setLeft(self.speed_left_claw)
+        self.claw.setRight(self.speed_right_claw)
 
         if not self.claw.seesObject():
             self.timer.start()
         else:
             self.timer.stop()
             self.timer.reset()
+
+        if not self.printer.isRight():
+            self.printer.moveRight()
+        else:
+            self.printer.stop()
 
     def isFinished(self) -> bool:
         return (
@@ -44,8 +52,8 @@ class LoadCoral(Command):
 class _ClassProperties:
     # Claw Properties #
     delay = autoproperty(0.0, subtable=LoadCoral.__name__)
-    speed_left = autoproperty(-0.6, subtable=LoadCoral.__name__)
-    speed_right = autoproperty(0.6, subtable=LoadCoral.__name__)
+    claw_speed_left = autoproperty(-0.6, subtable=LoadCoral.__name__)
+    claw_speed_right = autoproperty(0.6, subtable=LoadCoral.__name__)
 
 
 load_coral_properties = _ClassProperties()

--- a/modules/autonomous.py
+++ b/modules/autonomous.py
@@ -80,7 +80,7 @@ class AutonomousModule(Module):
                 self.hardware.elevator, self.hardware.printer, self.hardware.arm
             )
         )
-        registerNamedCommand(LoadCoral(self.hardware.claw))
+        registerNamedCommand(LoadCoral(self.hardware.claw, self.hardware.printer))
         registerNamedCommand(WaitUntilCoral(self.hardware.claw))
         registerNamedCommand(AlignWithReefSide(self.hardware.drivetrain))
         registerNamedCommand(RetractArm(self.hardware.arm))

--- a/modules/dashboard.py
+++ b/modules/dashboard.py
@@ -84,7 +84,7 @@ class DashboardModule(Module):
         putCommandOnDashboard("Claw", Drop.atLevel3(hardware.claw))
         putCommandOnDashboard("Claw", Drop.atLevel4(hardware.claw))
         putCommandOnDashboard("Claw", AutoDrop(hardware.claw, hardware.elevator))
-        putCommandOnDashboard("Claw", LoadCoral(hardware.claw))
+        putCommandOnDashboard("Claw", LoadCoral(hardware.claw, hardware.printer))
         putCommandOnDashboard("Claw", WaitUntilCoral(hardware.claw))
 
         """

--- a/modules/loadingdetection.py
+++ b/modules/loadingdetection.py
@@ -8,9 +8,10 @@ class LoadingDetectionModule(Module):
     def __init__(self, hardware: HardwareModule):
         super().__init__()
         self.claw = hardware.claw
+        self.printer = hardware.printer
         self.elevator = hardware.elevator
         self.printer = hardware.printer
-        self._load_command = LoadCoral(self.claw)
+        self._load_command = LoadCoral(self.claw, self.printer)
         self._is_at_loading = False
 
     def robotPeriodic(self) -> None:

--- a/subsystems/claw.py
+++ b/subsystems/claw.py
@@ -11,12 +11,10 @@ from ultime.timethis import tt
 class Claw(Subsystem):
     def __init__(self):
         super().__init__()
-        from commands.claw.loadcoral import LoadCoral
 
         self._motor_right = VictorSP(ports.PWM.claw_motor_right)
         self._motor_left = VictorSP(ports.PWM.claw_motor_left)
         self._sensor = Switch(Switch.Type.NormallyOpen, ports.DIO.claw_photocell)
-        self._load_command = LoadCoral(self)
         self.has_coral = False
         self.is_coral_retracted = False
 
@@ -54,9 +52,6 @@ class Claw(Subsystem):
 
     def seesObject(self):
         return self._sensor.isPressed()
-
-    def periodic(self) -> None:
-        pass
 
     def initSendable(self, builder: SendableBuilder) -> None:
         super().initSendable(builder)

--- a/tests/test_claw.py
+++ b/tests/test_claw.py
@@ -291,8 +291,12 @@ def test_LoadingDetection(robot_controller: RobotTestController, robot: Robot):
     claw._sensor.setSimUnpressed()
     assert not cmd_prepare_loading.isScheduled()
     assert robot.loading_detection._is_at_loading
-    assert claw._motor_right.get() == approx(load_coral_properties.speed_right, rel=0.1)
-    assert claw._motor_left.get() == approx(load_coral_properties.speed_left, rel=0.1)
+    assert claw._motor_right.get() == approx(
+        load_coral_properties.claw_speed_right, rel=0.1
+    )
+    assert claw._motor_left.get() == approx(
+        load_coral_properties.claw_speed_left, rel=0.1
+    )
     assert not claw.has_coral
 
     # The motors are stopped


### PR DESCRIPTION
# Description
<!--- Fais un résumé de ce que tu as ajouté. -->
Closes #177 . 

### Vérifications générales
- [ ] Code en anglais
- [ ] Noms de fichier en lettres minuscules et sans espace
- [ ] Noms de classe en `PascalCase`
- [ ] Noms de fonction en `camelCase`
- [ ] Noms de variables en `snake_case`
- [ ] Noms de fonction débutent par un verbe d'action (get, set, move, start,
  stop...)
- Ports
  - [ ] se trouvent dans `ports.py`
  - [ ] respectent la convention `subsystem_composante_precision` (p. ex. 
    `shooter_motor_left`)
- [ ] Chaque `autoproperty` respecte la convention `type_precision` (p.ex. 
  `speed_slow`, `height_max`, `distance_max`)
- [ ] Tests unitaires pour maintenir ou augmenter la couverture
- [ ] Chaque dossier est un module (contient `__init__.py`)

### Command
- [ ] Nom débute par un verbe d'action
- [ ] Ajoutée sur le Dashboard
- [ ] Ses paramètres sont dans des `autoproperty`
- [ ] Si pertinent (calculs), implémente `initSendable` pour afficher toute 
  information pertinente sur son état

### Subsystem
- [ ] Hérite de la classe `ultime.Subsystem` (et non `commands2.
Subsystem`)
- [ ] Ses composantes ont été liées au sous-système par `self.addChild()`
- [ ] Ses paramètres sont dans des `autoproperty`
- [ ] Implémente `initSendable` pour afficher toute information pertinente 
  sur son état
- [ ] Instancié et ajouté sur le Dashboard

